### PR TITLE
Simple formatting changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@
       <a href="https://visitorbadge.io/status?path=https%3A%2F%2Fgithub.com%2FBobdaProgrammer%2FdoWM"><img src="https://api.visitorbadge.io/api/visitors?path=https%3A%2F%2Fgithub.com%2FBobdaProgrammer%2FdoWM&label=visitors&labelColor=%23ff8a65&countColor=%23111133" /></a>
       <a href="https://github.com/BobdaProgrammer/doWM/issues" target="_blank">
       <img alt="Issues" src="https://img.shields.io/github/issues/BobdaProgrammer/doWM?style=for-the-badge&logo=bilibili&color=F5E0DC&logoColor=D9E0EE&labelColor=302D41" />
-    </a>  
+    </a>
        <a href="https://github.com/BobdaProgrammer/doWM/blob/main/LICENSE" target="_blank">
       <img alt="License" src="https://img.shields.io/github/license/BobdaProgrammer/doWM?style=for-the-badge&logo=starship&color=ee999f&logoColor=D9E0EE&labelColor=302D41" />
-    </a>  
+    </a>
 </p>
 
 ## Contents
@@ -36,13 +36,13 @@ I highly recommend that if you have any questions that aren't issue related, you
 <div align="center">
 <img src="https://github.com/BobdaProgrammer/doWM-web/blob/main/images/gruvbox.png?raw=true" width="500px">
 <img src="https://github.com/BobdaProgrammer/doWM-web/blob/main/images/pinkgradient.png?raw=true" width="500px">
-  
+
 <img src="https://github.com/BobdaProgrammer/doWM-web/blob/main/images/8windowsweirdlayout.png?raw=true" width="500px">
 <img src="https://github.com/BobdaProgrammer/doWM-web/blob/main/images/fabricnotification.png?raw=true" width="500px">
 
 <img src="https://github.com/BobdaProgrammer/doWM-web/blob/main/images/musicwithnotification.png?raw=true" width="500px">
 <img src="https://github.com/BobdaProgrammer/doWM-web/blob/main/images/workspaceviewergruvbox.png?raw=true" width="500px">
-</div>  
+</div>
 
 -------------
 
@@ -59,7 +59,7 @@ go build -o ./doWM
 make install
 ```
 
-then to see a normal config look at `exampleConfig` folder, you can copy this to ~/.config/doWM and then write your own configuration  
+then to see a normal config look at `exampleConfig` folder, you can copy this to ~/.config/doWM and then write your own configuration
 
 -------------
 
@@ -68,8 +68,8 @@ then to see a normal config look at `exampleConfig` folder, you can copy this to
 
 ```
 mkdir ~/.config/doWM
-cp -r ./exampleConfig/* ~/.config/doWM/ 
-chmod +x ~/.config/doWM/autostart.sh        
+cp -r ./exampleConfig/* ~/.config/doWM/
+chmod +x ~/.config/doWM/autostart.sh
 ```
 
 > [!NOTE]
@@ -92,7 +92,7 @@ You have a few general options:
 - unactive-border-color (the color for the border of unactive windows
 - active-border-color (the color for the border of an active window)
 
-The multi monitor system is fairly simple, you don't need to add it to your config but you can if you want to specify positions for your monitors. The only rule for the positions is they cannot be negative, this means that the monitor that is the highest has a Y of 0, where as ones lower than that could be somehting like 1080, same with X, the one on the furthest left would be 0, then to the right of that could be 1920. Here is an example of two monitors, one it above and to the right and the other below and to the left:
+The multi monitor system is fairly simple, you don't need to add it to your config but you can if you want to specify positions for your monitors. The only rule for the positions is they cannot be negative, this means that the monitor that is the highest has a Y of 0, where as ones lower than that could be something like 1080, same with X, the one on the furthest left would be 0, then to the right of that could be 1920. Here is an example of two monitors, one it above and to the right and the other below and to the left:
 ```yml
 monitors:
   # highest and to the right
@@ -105,7 +105,7 @@ monitors:
 ```
 To move a window between monitors, just drag it between and it will follow
 
-Although there are some default tiling layouts which will serve you well, you can easily customize your tiling layouts. The system works quite simply, in the `layouts:` you would have a list of each of the window numbers you want to have a layout/s for, for example 1 through 5 so you would have layouts for up to 5 windows in a workspace, any more than that and the window would just be placed above the windows to be moved to a seperate workspace or closed. For each window number, you specify `- windows:` for each layout, in side of windows you would have a list of windows, represented like this:
+Although there are some default tiling layouts which will serve you well, you can easily customize your tiling layouts. The system works quite simply, in the `layouts:` you would have a list of each of the window numbers you want to have a layout/s for, for example 1 through 5 so you would have layouts for up to 5 windows in a workspace, any more than that and the window would just be placed above the windows to be moved to a separate workspace or closed. For each window number, you specify `- windows:` for each layout, in side of windows you would have a list of windows, represented like this:
 ```yml
 - x: 0.0 # the X percentage in the tiling space, 0.5 would have the top left corner halfway through the width of the tiling space
   y: 0.0 # the Y percentage in the tiling space
@@ -161,7 +161,7 @@ each keybind either executes a command or plays a role in the wm. Here are all t
 - reload-config (reload doWM.yml)
 - increase-gap (increase gap between windows in tiling temporarily - reset next session)
 - decrease-gap (decrease gap between windows in tiling, also temporary)
-- detach-tiling (sepearate a workspace from global tiling - e.g that workspace could be floating with rest tiling - it is also toggling, so if detached it will re-attach)
+- detach-tiling (separate a workspace from global tiling - e.g that workspace could be floating with rest tiling - it is also toggling, so if detached it will re-attach)
 - next-layout (switch to the next layout for the current window number)
 - resize-x-scale-up (increases the width of the current window)
 - resize-x-scale-down (decreases the width of the current window)
@@ -174,7 +174,7 @@ each keybind either executes a command or plays a role in the wm. Here are all t
 
 each keybind also has a key and a shift option, key is the character of the key (can also be things like "f1" "space" or "return") and shift is a bool for if shift should be pressed or not to register.
 
-for example: 
+for example:
 ```yml
   # When mod + t is pressed then open kitty
   - key: "t"
@@ -206,7 +206,7 @@ doWM supports multiple monitors and you can see how to configure them in the con
 - [x] tiling
 - [x] swap windows in tiling
 - [x] change focus in tiling
-- [x] many layouts 
+- [x] many layouts
 - [x] bar support
 - [x] fullscreen
 - [x] startup commands

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 func main() {
 	WM, err := wm.Create()
 	if err != nil {
-		slog.Error("Couldn't initialise window manager", "error:", err)
+		slog.Error("Couldn't initialize window manager", "error:", err)
 		return
 	}
 	defer WM.Close()

--- a/wm/window_manager.go
+++ b/wm/window_manager.go
@@ -310,20 +310,20 @@ func Create() (*WindowManager, error) {
 	X, err := xgb.NewConn()
 	if err != nil {
 		slog.Error("Couldn't open X display", "error", err)
-		return nil, fmt.Errorf("couldn't open X display %w", err)
+		return nil, fmt.Errorf("could not open X display %w", err)
 	}
 
 	// Every extension must be initialized before it can be used.
 	err = randr.Init(X)
 	if err != nil {
 		slog.Error("Couldn't init", "error:", err)
-		return nil, fmt.Errorf("couldn't use randr for monitors %w", err)
+		return nil, fmt.Errorf("could not use randr for monitors %w", err)
 	}
 
 	// get xgbutil connection aswell for keybinds
 	XUtil, err = xgbutil.NewConnXgb(X)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't create xgbutil connection: %w", err)
+		return nil, fmt.Errorf("could not create xgbutil connection: %w", err)
 	}
 
 	keybind.Initialize(XUtil)
@@ -339,7 +339,7 @@ func Create() (*WindowManager, error) {
 	resources, err := randr.GetScreenResources(X, root).Reply()
 	if err != nil {
 		slog.Error("Couldn't get resources", "error:", err)
-		return nil, fmt.Errorf("couldn't get resources %w", err)
+		return nil, fmt.Errorf("could not get resources %w", err)
 	}
 
 	monitors := []Monitor{}
@@ -492,7 +492,7 @@ func (wm *WindowManager) createKeybind(kb *Keybind) Keybind {
 	err := xproto.GrabKeyChecked(wm.conn, true, wm.root, Mask, KeyCode, xproto.GrabModeAsync, xproto.GrabModeAsync).
 		Check()
 	if err != nil {
-		slog.Error("couldn't grab key", "error:", err)
+		slog.Error("Couldn't grab key", "error:", err)
 	}
 
 	err = xproto.GrabKeyChecked(
@@ -506,7 +506,7 @@ func (wm *WindowManager) createKeybind(kb *Keybind) Keybind {
 	).
 		Check()
 	if err != nil {
-		slog.Error("couldn't grab key", "error:", err)
+		slog.Error("Couldn't grab key", "error:", err)
 	}
 	numlock := getNumLockMask(wm.conn)
 	if numlock != wm.mod {
@@ -522,7 +522,7 @@ func (wm *WindowManager) createKeybind(kb *Keybind) Keybind {
 			Check()
 	}
 	if err != nil {
-		slog.Error("couldn't create keybind", "error:", err)
+		slog.Error("Couldn't create keybind", "error:", err)
 	}
 
 	return *kb
@@ -576,14 +576,14 @@ func (wm *WindowManager) reload(focused xproto.ButtonPressEvent) {
 			).
 				Check()
 			if err != nil {
-				slog.Error("couldn't set border width", "error", err)
+				slog.Error("Couldn't set border width", "error", err)
 			}
 
 			// Set border color
 			err = xproto.ChangeWindowAttributesChecked(wm.conn, window, xproto.CwBorderPixel, []uint32{col}).
 				Check()
 			if err != nil {
-				slog.Error("couldn't set border color", "error", err)
+				slog.Error("Couldn't set border color", "error", err)
 			}
 		}
 	}
@@ -696,7 +696,7 @@ func (wm *WindowManager) Run() { //nolint:cyclop
 	).Check()
 	if err != nil {
 		if err.Error() == "BadAccess" {
-			slog.Error("other window manager running on display")
+			slog.Error("Other window manager running on display")
 			return
 		}
 	}
@@ -746,7 +746,7 @@ func (wm *WindowManager) Run() { //nolint:cyclop
 	root, TopLevelWindows := tree.Root, tree.Children
 
 	if root != wm.root {
-		slog.Error("tree root not equal to window manager root")
+		slog.Error("Tree root not equal to window manager root")
 		return
 	}
 
@@ -758,7 +758,7 @@ func (wm *WindowManager) Run() { //nolint:cyclop
 
 	err = xproto.UngrabServerChecked(wm.conn).Check()
 	if err != nil {
-		slog.Error("couldn't ungrab server", "error:", err.Error())
+		slog.Error("Couldn't ungrab server", "error:", err.Error())
 		return
 	}
 
@@ -802,7 +802,7 @@ func (wm *WindowManager) Run() { //nolint:cyclop
 	).
 		Check()
 	if err != nil {
-		slog.Error("couldn't grab button", "error:", err.Error())
+		slog.Error("Couldn't grab button", "error:", err.Error())
 	}
 
 	err = xproto.GrabButtonChecked(
@@ -819,7 +819,7 @@ func (wm *WindowManager) Run() { //nolint:cyclop
 	).
 		Check()
 	if err != nil {
-		slog.Error("couldn't grab window+c key", "error:", err.Error())
+		slog.Error("Couldn't grab window+c key", "error:", err.Error())
 	}
 
 	// for moving and resizing, basically the window that will be moved/resized
@@ -852,7 +852,7 @@ func (wm *WindowManager) Run() { //nolint:cyclop
 		// get next event
 		event, err := wm.conn.WaitForEvent()
 		if err != nil {
-			slog.Error("event error", "error:", err.Error())
+			slog.Error("Event error", "error:", err.Error())
 			continue
 		}
 		if event == nil {
@@ -875,7 +875,7 @@ func (wm *WindowManager) Run() { //nolint:cyclop
 			err := xproto.SetInputFocusChecked(wm.conn, xproto.InputFocusPointerRoot, wm.root, xproto.TimeCurrentTime).
 				Check()
 			if err != nil {
-				slog.Error("could not set input focus", "error", err)
+				slog.Error("Couldn't set input focus", "error", err)
 			}
 		}
 		switch ev := event.(type) {
@@ -1056,7 +1056,7 @@ func (wm *WindowManager) Run() { //nolint:cyclop
 						case "resize-x-scale-up":
 							if wm.currMonitor.CurrWorkspace.tiling {
 								if err := wm.pointerToWindow(ev.Child); err != nil {
-									slog.Error("couldn't move pointer to window", "error:", err)
+									slog.Error("Couldn't move pointer to window", "error:", err)
 								}
 								if !wm.resizeTiledX(true, ev) {
 									break
@@ -1069,13 +1069,13 @@ func (wm *WindowManager) Run() { //nolint:cyclop
 								xproto.ConfigureWindowChecked(wm.conn, ev.Child, xproto.ConfigWindowWidth,
 									[]uint32{uint32(geom.Width + uint16(wm.config.Resize))})
 								if err := wm.pointerToWindow(ev.Child); err != nil {
-									slog.Error("couldn't move pointer to window", "error:", err)
+									slog.Error("Couldn't move pointer to window", "error:", err)
 								}
 							}
 						case "resize-x-scale-down":
 							if wm.currMonitor.CurrWorkspace.tiling {
 								if err := wm.pointerToWindow(ev.Child); err != nil {
-									slog.Error("couldn't move pointer to window", "error:", err)
+									slog.Error("Couldn't move pointer to window", "error:", err)
 								}
 								if !wm.resizeTiledX(false, ev) {
 									break
@@ -1089,14 +1089,14 @@ func (wm *WindowManager) Run() { //nolint:cyclop
 									xproto.ConfigureWindowChecked(wm.conn, ev.Child, xproto.ConfigWindowWidth,
 										[]uint32{uint32(geom.Width - uint16(wm.config.Resize))})
 									if err := wm.pointerToWindow(ev.Child); err != nil {
-										slog.Error("couldn't move pointer to window", "error:", err)
+										slog.Error("Couldn't move pointer to window", "error:", err)
 									}
 								}
 							}
 						case "resize-y-scale-up":
 							if wm.currMonitor.CurrWorkspace.tiling {
 								if err := wm.pointerToWindow(ev.Child); err != nil {
-									slog.Error("couldn't move pointer to window", "error:", err)
+									slog.Error("Couldn't move pointer to window", "error:", err)
 								}
 								if !wm.resizeTiledY(true, ev) {
 									break
@@ -1109,13 +1109,13 @@ func (wm *WindowManager) Run() { //nolint:cyclop
 								xproto.ConfigureWindowChecked(wm.conn, ev.Child, xproto.ConfigWindowHeight,
 									[]uint32{uint32(geom.Height + uint16(wm.config.Resize))})
 								if err := wm.pointerToWindow(ev.Child); err != nil {
-									slog.Error("couldn't move pointer to window", "error:", err)
+									slog.Error("Couldn't move pointer to window", "error:", err)
 								}
 							}
 						case "resize-y-scale-down":
 							if wm.currMonitor.CurrWorkspace.tiling {
 								if err := wm.pointerToWindow(ev.Child); err != nil {
-									slog.Error("couldn't move pointer to window", "error:", err)
+									slog.Error("Couldn't move pointer to window", "error:", err)
 								}
 								if !wm.resizeTiledY(false, ev) {
 									break
@@ -1132,7 +1132,7 @@ func (wm *WindowManager) Run() { //nolint:cyclop
 									xproto.ConfigureWindowChecked(wm.conn, ev.Child, xproto.ConfigWindowHeight,
 										[]uint32{uint32(geom.Height - uint16(wm.config.Resize))})
 									if err := wm.pointerToWindow(ev.Child); err != nil {
-										slog.Error("couldn't move pointer to window", "error:", err)
+										slog.Error("Couldn't move pointer to window", "error:", err)
 									}
 								}
 							}
@@ -1146,7 +1146,7 @@ func (wm *WindowManager) Run() { //nolint:cyclop
 							}
 							xproto.ConfigureWindowChecked(wm.conn, ev.Child, xproto.ConfigWindowX, []uint32{uint32(geom.X + 10)})
 							if err := wm.pointerToWindow(ev.Child); err != nil {
-								slog.Error("couldn't move pointer to window", "error:", err)
+								slog.Error("Couldn't move pointer to window", "error:", err)
 							}
 						case "move-x-left":
 							if wm.currMonitor.CurrWorkspace.tiling {
@@ -1158,7 +1158,7 @@ func (wm *WindowManager) Run() { //nolint:cyclop
 							}
 							xproto.ConfigureWindowChecked(wm.conn, ev.Child, xproto.ConfigWindowX, []uint32{uint32(geom.X - 10)})
 							if err := wm.pointerToWindow(ev.Child); err != nil {
-								slog.Error("couldn't move pointer to window", "error:", err)
+								slog.Error("Couldn't move pointer to window", "error:", err)
 							}
 						case "move-y-up":
 							if wm.currMonitor.CurrWorkspace.tiling {
@@ -1170,7 +1170,7 @@ func (wm *WindowManager) Run() { //nolint:cyclop
 							}
 							xproto.ConfigureWindowChecked(wm.conn, ev.Child, xproto.ConfigWindowY, []uint32{uint32(geom.Y - 10)})
 							if err := wm.pointerToWindow(ev.Child); err != nil {
-								slog.Error("couldn't move pointer to window", "error:", err)
+								slog.Error("Couldn't move pointer to window", "error:", err)
 							}
 						case "move-y-down":
 							if wm.currMonitor.CurrWorkspace.tiling {
@@ -1182,7 +1182,7 @@ func (wm *WindowManager) Run() { //nolint:cyclop
 							}
 							xproto.ConfigureWindowChecked(wm.conn, ev.Child, xproto.ConfigWindowY, []uint32{uint32(geom.Y + 10)})
 							if err := wm.pointerToWindow(ev.Child); err != nil {
-								slog.Error("couldn't move pointer to window", "error:", err)
+								slog.Error("Couldn't move pointer to window", "error:", err)
 							}
 						case "quit":
 							if _, ok := wm.windows[ev.Child]; ok {
@@ -1228,7 +1228,7 @@ func (wm *WindowManager) Run() { //nolint:cyclop
 										}
 										wm.fitToLayout()
 										if err := wm.pointerToWindow(currWindow); err != nil {
-											slog.Error("couldn't move pointer to window", "error:", err)
+											slog.Error("Couldn't move pointer to window", "error:", err)
 										}
 										break swapLeft
 									}
@@ -1248,7 +1248,7 @@ func (wm *WindowManager) Run() { //nolint:cyclop
 										}
 										wm.fitToLayout()
 										if err := wm.pointerToWindow(currWindow); err != nil {
-											slog.Error("couldn't move pointer to window", "error:", err)
+											slog.Error("Couldn't move pointer to window", "error:", err)
 										}
 										break swapRight
 									}
@@ -1262,11 +1262,11 @@ func (wm *WindowManager) Run() { //nolint:cyclop
 									if currWindow == wm.currMonitor.CurrWorkspace.windowList[i].id {
 										if i == len(wm.currMonitor.CurrWorkspace.windowList)-1 {
 											if err := wm.pointerToWindow(wm.currMonitor.CurrWorkspace.windowList[0].id); err != nil {
-												slog.Error("couldn't move pointer to window", "error:", err)
+												slog.Error("Couldn't move pointer to window", "error:", err)
 											}
 										} else {
 											if err := wm.pointerToWindow(wm.currMonitor.CurrWorkspace.windowList[i+1].id); err != nil {
-												slog.Error("couldn't move pointer to window", "error:", err)
+												slog.Error("Couldn't move pointer to window", "error:", err)
 											}
 										}
 										break focusRight
@@ -1282,11 +1282,11 @@ func (wm *WindowManager) Run() { //nolint:cyclop
 										if i == 0 {
 											err := wm.pointerToWindow(wm.currMonitor.CurrWorkspace.windowList[len(wm.currMonitor.CurrWorkspace.windowList)-1].id)
 											if err != nil {
-												slog.Error("couldn't move pointer to window", "error:", err)
+												slog.Error("Couldn't move pointer to window", "error:", err)
 											}
 										} else {
 											if err := wm.pointerToWindow(wm.currMonitor.CurrWorkspace.windowList[i-1].id); err != nil {
-												slog.Error("couldn't move pointer to window", "error:", err)
+												slog.Error("Couldn't move pointer to window", "error:", err)
 											}
 										}
 										break focusLeft
@@ -1602,7 +1602,7 @@ func (wm *WindowManager) declareSupportedAtoms() {
 	for _, name := range atomNames {
 		atom, err := xproto.InternAtom(wm.conn, false, uint16(len(name)), name).Reply()
 		if err != nil {
-			slog.Error("intern atom", "name", name, "err", err)
+			slog.Error("Intern atom", "name", name, "err", err)
 			continue
 		}
 		wm.atoms[name] = atom.Atom
@@ -1627,7 +1627,7 @@ func (wm *WindowManager) declareSupportedAtoms() {
 		data,
 	).Check()
 	if err != nil {
-		slog.Error("could not set _NET_SUPPORTED", "err", err)
+		slog.Error("Couldn't set _NET_SUPPORTED", "err", err)
 	}
 }
 
@@ -1676,7 +1676,7 @@ func runCommand(cmdStr string) {
 	parser := shellwords.NewParser()
 	args, err := parser.Parse(cmdStr)
 	if err != nil {
-		slog.Error("parse error:", "error:", err)
+		slog.Error("Parsing error:", "error:", err)
 		return
 	}
 	if len(args) == 0 {
@@ -1965,7 +1965,7 @@ func (wm *WindowManager) disableFullscreen(win *Window, child xproto.Window) {
 		},
 	).Check()
 	if err != nil {
-		slog.Error("couldn't un fullscreen window", "error: ", err)
+		slog.Error("Couldn't un-fullscreen window", "error: ", err)
 	}
 	wm.removeFullScreenEWMH(child)
 	wm.fitToLayout()
@@ -2047,7 +2047,7 @@ func (wm *WindowManager) fullscreen(_ *Window, child xproto.Window) {
 		},
 	).Check()
 	if err != nil {
-		slog.Error("couldn't fullscreen window", "error:", err)
+		slog.Error("Couldn't fullscreen window", "error:", err)
 	}
 	wm.setFullScreenEWMH(child)
 }
@@ -2102,14 +2102,14 @@ func (wm *WindowManager) broadcastWorkspace(num int) {
 	).
 		Reply()
 	if err != nil {
-		slog.Error("intern _NET_CURRENT_DESKTOP", "error:", err)
+		slog.Error("Intern _NET_CURRENT_DESKTOP", "error:", err)
 		return
 	}
 
 	cardinalAtom, err := xproto.InternAtom(wm.conn, true, uint16(len("CARDINAL")), "CARDINAL").
 		Reply()
 	if err != nil {
-		slog.Error("intern CARDINAL", "error:", err)
+		slog.Error("Intern CARDINAL", "error:", err)
 		return
 	}
 	fmt.Println(netCurrentDesktopAtom.Atom)
@@ -2125,7 +2125,7 @@ func (wm *WindowManager) broadcastWorkspace(num int) {
 		data,
 	).Check()
 	if err != nil {
-		slog.Error("couldn't set _NET_CURRENT_DESKTOP", "error:", err)
+		slog.Error("Couldn't set _NET_CURRENT_DESKTOP", "error:", err)
 	}
 
 	wm.broadcastWorkspaceCount()
@@ -2178,7 +2178,7 @@ func (wm *WindowManager) sendWmDelete(conn *xgb.Conn, window xproto.Window) erro
 	prop, err := xproto.GetProperty(conn, false, window, wmProtocolsAtom.Atom, xproto.AtomAtom, 0, (1<<32)-1).
 		Reply()
 	if err != nil || prop.Format != 32 {
-		return fmt.Errorf("couldn't get WM_PROTOCOLS %w", err)
+		return fmt.Errorf("could not get WM_PROTOCOLS %w", err)
 	}
 
 	supportsDelete := false
@@ -2230,7 +2230,7 @@ func (wm *WindowManager) onLeaveNotify(event xproto.LeaveNotifyEvent) {
 		},
 	).Check()
 	if err != nil {
-		slog.Error("couldn't remove focus from window", "error:", err)
+		slog.Error("Couldn't remove focus from window", "error:", err)
 	}
 }
 
@@ -2320,7 +2320,7 @@ func (wm *WindowManager) setNetWorkArea() {
 		buf.Bytes(),
 	).Check()
 	if err != nil {
-		slog.Error("couldn't set the work area", "error:", err)
+		slog.Error("Couldn't set the work area", "error:", err)
 	}
 }
 
@@ -2349,7 +2349,7 @@ func (wm *WindowManager) onEnterNotify(event xproto.EnterNotifyEvent) {
 	err := xproto.SetInputFocusChecked(wm.conn, xproto.InputFocusPointerRoot, event.Event, xproto.TimeCurrentTime).
 		Check()
 	if err != nil {
-		slog.Error("couldn't set input focus", "error", err)
+		slog.Error("Couldn't set input focus", "error", err)
 	}
 	Col := wm.config.BorderActive
 	err = xproto.ChangeWindowAttributesChecked(
@@ -2362,7 +2362,7 @@ func (wm *WindowManager) onEnterNotify(event xproto.EnterNotifyEvent) {
 		},
 	).Check()
 	if err != nil {
-		slog.Error("couldn't set focus on window", "error:", err)
+		slog.Error("Couldn't set focus on window", "error:", err)
 	}
 	wm.setNetActiveWindow(event.Event)
 }
@@ -2404,7 +2404,7 @@ func (wm *WindowManager) onUnmapNotify(event xproto.UnmapNotifyEvent) {
 		fmt.Println("IN UNMAPPING COULDNT FIND WIN NOW SEARCHING")
 		ok, index, _ := wm.findWindow(event.Window)
 		if !ok {
-			slog.Info("couldn't unmap since window wasn't in clients")
+			slog.Info("Couldn't unmap since window wasn't in clients")
 			fmt.Println(event.Window)
 			return
 		}
@@ -2430,7 +2430,7 @@ func (wm *WindowManager) remDestroyedWin(window xproto.Window) {
 		fmt.Println("IN UNMAPPING COULDNT FIND WIN NOW SEARCHING")
 		ok, index, _ := wm.findWindow(window)
 		if !ok {
-			slog.Info("couldn't unmap since window wasn't in clients")
+			slog.Info("Couldn't unmap since window wasn't in clients")
 			fmt.Println(window)
 			return
 		}
@@ -2452,7 +2452,7 @@ func (wm *WindowManager) unFrame(w xproto.Window, _ bool) {
 		w,
 	).Check()
 	if err != nil {
-		slog.Error("couldn't unmap frame", "error:", err.Error())
+		slog.Error("Couldn't unmap frame", "error:", err.Error())
 	}
 	// remove window and frame from current workspace record
 	remove(&wm.currMonitor.CurrWorkspace.windowList, w)
@@ -2466,7 +2466,7 @@ func (wm *WindowManager) unFrame(w xproto.Window, _ bool) {
 		w,
 	).Check()
 	if err != nil {
-		slog.Error("couldn't remove window from save", "error:", err.Error())
+		slog.Error("Couldn't remove window from save", "error:", err.Error())
 	}
 
 	// destroy frame
@@ -2475,7 +2475,7 @@ func (wm *WindowManager) unFrame(w xproto.Window, _ bool) {
 		w,
 	).Check()
 	if err != nil {
-		slog.Error("couldn't destroy frame", "error:", err.Error())
+		slog.Error("Couldn't destroy frame", "error:", err.Error())
 		return
 	}
 
@@ -2755,7 +2755,7 @@ func (wm *WindowManager) frame(w xproto.Window, createdBeforeWM bool) {
 		},
 	).Check()
 	if err != nil {
-		slog.Error("couldn't save window attributes", "error:", err.Error())
+		slog.Error("Couldn't save window attributes", "error:", err.Error())
 		return
 	}
 	// add it to the x11 save set
@@ -2773,7 +2773,7 @@ func (wm *WindowManager) frame(w xproto.Window, createdBeforeWM bool) {
 		xproto.EventMaskEnterWindow | xproto.EventMaskLeaveWindow,
 	}).Check()
 	if err != nil {
-		slog.Error("failed to set event mask on window", "error:", err)
+		slog.Error("Failed to set event mask on window", "error:", err)
 	}
 
 	setFrameWindowType(wm.conn, w)
@@ -2818,7 +2818,7 @@ func (wm *WindowManager) onConfigureRequest(event xproto.ConfigureRequestEvent) 
 		changes,
 	).Check()
 	if err != nil {
-		slog.Error("couldn't configure window", "error:", err.Error())
+		slog.Error("Couldn't configure window", "error:", err.Error())
 	}
 }
 

--- a/wm/window_manager.go
+++ b/wm/window_manager.go
@@ -1,4 +1,4 @@
-// Package wm provides a X11 window manager.
+// Package wm provides an X11 window manager.
 package wm
 
 import (
@@ -51,7 +51,7 @@ type MonitorConfig struct {
 }
 
 // Keybind represents a keybind: keycode, the letter of the key, if shift should be pressed,
-// command (can be empty), role in wm (can be empty)k.
+// command (can be empty), role in wm (can be empty).
 type Keybind struct {
 	Keycode uint32
 	Key     string `yaml:"key"`
@@ -60,7 +60,7 @@ type Keybind struct {
 	Role    string `yaml:"role"`
 }
 
-// LayoutWindow represensts where a window is on a layout (dynamic by using percentages).
+// LayoutWindow represents where a window is on a layout (dynamic by using percentages).
 type LayoutWindow struct {
 	WidthPercentage  float64 `yaml:"width"`
 	HeightPercentage float64 `yaml:"height"`
@@ -68,7 +68,7 @@ type LayoutWindow struct {
 	YPercentage      float64 `yaml:"y"`
 }
 
-// Layout represensts a tiling layout of windows.
+// Layout represents a tiling layout of windows.
 type Layout struct {
 	Windows []LayoutWindow `yaml:"windows"`
 }
@@ -99,7 +99,7 @@ type Space struct {
 }
 
 // Workspace is a map from client windows to the frame, the reverse of that, window IDs to windows, and if that
-// workspace is tiling or not (incase it needs to update to sync with the main wm).
+// workspace is tiling or not (in case it needs to update to sync with the main wm).
 type Workspace struct {
 	tiling        bool
 	layoutIndex   int
@@ -110,8 +110,7 @@ type Workspace struct {
 }
 
 // Monitor is representing a monitor which effectively houses its own workspaces and windows etc. the monitor is
-// actually just a space in the root
-// window
+// actually just a space in the root window
 type Monitor struct {
 	X              int16
 	Y              int16
@@ -128,7 +127,7 @@ type Monitor struct {
 
 // WindowManager represents the connection, root window, width and height of screen, workspaces,
 // the current workspace index,the current workspace, atoms for EMWH, if the wm is tiling, the space for tiling
-// windows to be, the different tiling layouts, the wm condig, the mod key.
+// windows to be, the different tiling layouts, the wm config, the mod key.
 type WindowManager struct {
 	conn          *xgb.Conn
 	root          xproto.Window
@@ -179,7 +178,6 @@ func (wm *WindowManager) cursor() { //nolint:unused
 }
 
 // creates simple tiling layouts for 1-4 windows, any more is simply left on top to be moved
-
 func createLayouts() map[int][]Layout {
 	return map[int][]Layout{
 		1: {{
@@ -726,7 +724,7 @@ func (wm *WindowManager) Run() { //nolint:cyclop
 	wm.broadcastWorkspace(0)
 	wm.broadcastWorkspaceCount()
 
-	// grab the server whilst we manage pre-exisiting windows
+	// grab the server whilst we manage pre-existing windows
 	err = xproto.GrabServerChecked(
 		wm.conn,
 	).Check()


### PR DESCRIPTION
Just some simple formatting changes.

Golang error objects should have their first character lower case. Other error logs should use sentence case as they are printed in console as is.