### PR TITLE
Make DoWM quit rather than consume 100% of the cpu when there is no xserver

### DIFF
--- a/wm/window_manager.go
+++ b/wm/window_manager.go
@@ -856,7 +856,7 @@ func (wm *WindowManager) Run() { //nolint:cyclop
 			continue
 		}
 		if event == nil {
-			continue
+			return
 		}
 
 		pointer, ptrerr := xproto.QueryPointer(wm.conn, wm.root).Reply()


### PR DESCRIPTION
The current behavior is to continue the Run loop if there is no event received from the XGB connection. However, the XGB docs say that this means the connection is either closed or XGB received a malformed response [[link]](https://github.com/jezek/xgb/blob/173fab59d6200a1502285d5d66cc21c732122a96/xgb.go#L567C1-L583C2). Both of these are fatal errors. Therefore I think it is best to return and quit the program. 

I think it is also worth discussing if the program should retry connecting. I wrote a patch for this as well. If you think that would be useful, I can submit it.

I discovered this while setting up a Xephyr debug environment and noticing my CPU usage spiking after I closed the window.